### PR TITLE
preprocess_version_step default value to transitional schema

### DIFF
--- a/schema_old.py
+++ b/schema_old.py
@@ -130,5 +130,7 @@ SCHEMA = {
             "name": "metadata",
             "type": METADATA,
         },
+        {"name": "preprocess_step_id", "type": "string", "default": "transitional_pipeline"},
+        {"name": "preprocess_step_version", "type": "string", "default": "1.0.0"},
     ],
 }


### PR DESCRIPTION
Add default values for:
```
        {"name": "preprocess_step_id", "type": "string", "default": "transitional_pipeline"},
        {"name": "preprocess_step_version", "type": "string", "default": "1.0.0"},
```